### PR TITLE
bugfix: fix request hangs up when agent failed to return PacketType_DIAL_RSP

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,6 +39,10 @@ import (
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
+var (
+	ConnectionSetupTimeout = 15 * time.Second
+)
+
 // ProxyClientConnection...
 type ProxyClientConnection struct {
 	Mode      string
@@ -75,9 +79,33 @@ func (c *ProxyClientConnection) send(pkt *client.Packet) error {
 }
 
 func NewPendingDialManager() *PendingDialManager {
-	return &PendingDialManager{
+	pm := &PendingDialManager{
 		pendingDial: make(map[int64]*ProxyClientConnection),
 	}
+
+	// spawn a goroutine to verify connection waiting is timeout or not.
+	go func() {
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				pm.mu.Lock()
+				for random, proxyClientConn := range pm.pendingDial {
+					// client connection pending over 15seconds
+					if time.Since(proxyClientConn.start) > ConnectionSetupTimeout {
+						delete(pm.pendingDial, random)
+						close(proxyClientConn.connected)
+						klog.V(2).InfoS("connection setup timeout", "random", random)
+					}
+				}
+				pm.mu.Unlock()
+			}
+		}
+	}()
+
+	return pm
 }
 
 type PendingDialManager struct {


### PR DESCRIPTION
when anp agent doesn't return response after 15seconds, tunnel server will take timeout process for proxy client connection. if no timeout for response, the request will be hang up